### PR TITLE
Clarify wording tone field in policy task

### DIFF
--- a/src/requirements_crew/tasks.py
+++ b/src/requirements_crew/tasks.py
@@ -3,14 +3,20 @@ from crewai import Task
 from textwrap import dedent
 from .models import PolicyClarifications, DraftOutput, ValidationResult
 
+
 def build_policy_task(agent, spec: str) -> Task:
+    """Create a task that elicits a PolicyClarifications.
+
+    The Policy model uses ``wording_tone`` as the field name, so this wording must be
+    preserved in the generated policy description.
+    """
     return Task(
         description=dedent(f"""
             You receive the following raw spec:
             ---
             {spec}
             ---
-            1) Derive a house policy (tone, style rules, banned phrases, acceptance test format, ID prefix).
+            1) Derive a house policy (wording_tone, style rules, banned phrases, acceptance test format, ID prefix).
             2) List top uncertainties as clarification questions; propose an answer and confidence for each.
             Output MUST be a valid PolicyClarifications (JSON only).
         """).strip(),


### PR DESCRIPTION
## Summary
- Update build_policy_task instructions to use `wording_tone`
- Document that the Policy model expects `wording_tone`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689aaf88a53c8320b8a9d42aa90ab785